### PR TITLE
fixed sql syntax errors 

### DIFF
--- a/4_CLEANUP_AND_CONVERT_SPELLS.sql
+++ b/4_CLEANUP_AND_CONVERT_SPELLS.sql
@@ -59,7 +59,20 @@ UPDATE character_skills SET VALUE=MAX WHERE VALUE>MAX;
 -- first delete skill
 SET @cnt := 0;
 SET @prevguid := 0;
-DELETE s FROM character_skills s JOIN ((SELECT guid, skill FROM ((SELECT IF(@prevguid <> cs.guid, @cnt := 1, @cnt := @cnt+1) AS cnt, (@prevguid := guid) AS guid, cs.skill AS skill FROM character_skills cs JOIN __profession_skill t ON cs.skill = t.skill AND t.rank=6 ORDER BY cs.guid, cs.skill) X) WHERE cnt>2) x2) ON s.guid = x2.guid AND s.skill = x2.skill;
+DELETE s FROM character_skills s 
+JOIN (
+    SELECT guid, skill        
+    FROM (
+        SELECT IF(@prevguid <> cs.guid, @cnt := 1, @cnt := @cnt+1) AS cnt, 
+               (@prevguid := guid) AS guid,
+               cs.skill AS skill 
+        FROM character_skills cs 
+        JOIN __profession_skill t ON cs.skill = t.skill AND t.rank=6
+        ORDER BY cs.guid, cs.skill
+    ) AS X
+    WHERE cnt > 2            
+) AS Y  -- This is the alias for the outer query
+ON s.guid = Y.guid AND s.skill = Y.skill;
 -- now delete main profession spells if skill is missing
 DELETE s FROM character_spell s JOIN __profession_skill t ON s.spell = t.spell LEFT JOIN character_skills cs ON s.guid = cs.guid AND t.skill = cs.skill WHERE cs.guid IS NULL;
 

--- a/5_FINAL_CLEANUP.sql
+++ b/5_FINAL_CLEANUP.sql
@@ -46,11 +46,12 @@ DELETE FROM petition_sign WHERE playerguid NOT IN (SELECT guid FROM characters);
 -- 5.2. Delete inexistent group members
 DELETE FROM group_member WHERE memberGuid NOT IN (SELECT guid FROM characters);
 -- 5.3. Delete members for inexistent groups
-DELETE FROM group_member WHERE guid NOT IN (SELECT guid FROM groups);
+DELETE FROM group_member WHERE guid NOT IN (SELECT guid FROM `groups`);
 -- 5.4. Delete empty groups
 DELETE FROM groups WHERE guid NOT IN (SELECT guid FROM group_member);
 -- 5.5. Delete referencing data for inexistent groups
-DELETE FROM group_instance WHERE guid NOT IN (SELECT guid FROM groups);
+DELETE FROM group_instance WHERE guid NOT IN (SELECT guid FROM `groups`);
+
 
 -- 6. Cleanup guild tables
 -- 6.1. Delete guilds with inexistent leader


### PR DESCRIPTION
'groups' is a reserved word in 8.0.2+
I dont know the version dependence of the required alias for subquery